### PR TITLE
Fix dbDataType() for AsIs object

### DIFF
--- a/R/data-types.R
+++ b/R/data-types.R
@@ -23,7 +23,8 @@ check_raw_list <- function(x) {
 }
 
 as_is_data_type <- function(x) {
-  dbiDataType(unclass(x))
+  oldClass(x) <- oldClass(x)[-1]
+  dbiDataType(x)
 }
 
 setOldClass("difftime")

--- a/tests/testthat/test-data-type.R
+++ b/tests/testthat/test-data-type.R
@@ -7,3 +7,15 @@ test_that("dbDataType works on a data frame", {
   expect_equal(types, c(x = "INT", y = "DOUBLE"))
 
 })
+
+test_that("dbDataType works on AsIs", {
+  drv <- MockDriver()
+
+  int_value <- 1L
+  expect_equal(dbDataType(drv, int_value), "INT")
+  expect_equal(dbDataType(drv, I(int_value)), "INT")
+
+  date_value <- structure(17455, class = "Date")
+  expect_equal(dbDataType(drv, date_value), "DATE")
+  expect_equal(dbDataType(drv, I(date_value)), "DATE")
+})


### PR DESCRIPTION
Current implementation of `dbiDataType()` for `AsIs` fails to restore the original class attributes. (I found this when I was trying to cheat DBItest with `ANSI()`...)

```r
library(DBI)
library(DBItest)

dbObj <- structure(list(), class = "DBIDriver")
testthat::expect_equal(
  dbDataType(dbObj, I(structure(17455, class = "Date"))),
  dbDataType(dbObj, structure(17455, class = "Date"))
)
#> Error: dbDataType(dbObj, I(structure(17455, class = "Date"))) not equal to dbDataType(dbObj, structure(17455, class = "Date")).
#> 1/1 mismatches
#> x[1]: "DOUBLE"
#> y[1]: "DATE"
```

`unclass()` is OK for implicit classes (e.g. `numeric` and `integer`), but `Date` needs to be set as `class` attribute explicitly. I believe `oldClass(x) <- oldClass(x)[-1]` is the reverse of what `I()` does.

```r
body(selectMethod("dbiDataType", "AsIs"))
#> {
#>     .local <- function (x) 
#>     {
#>         dbiDataType(unclass(x))
#>     }
#>     .local(x, ...)
#> }

body(I)
#> {
#>     structure(x, class = unique(c("AsIs", oldClass(x))))
#> }
```