### PR TITLE
Pass missing value argument to secondary dbWriteTable call

### DIFF
--- a/R/DBConnection.R
+++ b/R/DBConnection.R
@@ -521,9 +521,9 @@ setGeneric("dbWriteTable",
 
 #' @rdname hidden_aliases
 #' @export
-setMethod("dbWriteTable", signature("DBIConnection", "Id"),
-  function(conn, name, ...) {
-    dbWriteTable(conn, dbQuoteIdentifier(conn, name), ...)
+setMethod("dbWriteTable", signature("DBIConnection", "Id", "ANY"),
+  function(conn, name, value, ...) {
+    dbWriteTable(conn, dbQuoteIdentifier(conn, name), value, ...)
   }
 )
 


### PR DESCRIPTION
The dbWriteTable generic defines declares three arguments conn, name and
value, however the dbWriteTable(DBIConnection, Id) method only passes
the first two on. The issue is apparent when retrieving the method
definition.

    getMethod("dbWriteTable", signature("DBIConnection", "Id"))
    #> Method Definition:
    #>
    #> function (conn, name, value, ...)
    #> {
    #>     dbWriteTable(conn, dbQuoteIdentifier(conn, name), ...)
    #> }

Fixes https://github.com/r-dbi/DBI/issues/229