### PR TITLE
Avoid parial arg match in dbWriteTable

### DIFF
--- a/R/table-insert.R
+++ b/R/table-insert.R
@@ -148,6 +148,6 @@ setMethod("dbAppendTable", signature("DBIConnection"),
       ...
     )
     values <- sqlRownamesToColumn(value, row.names)
-    dbExecute(conn, query, param = unname(as.list(value)))
+    dbExecute(conn, query, params = unname(as.list(value)))
   }
 )


### PR DESCRIPTION
Minimal example to trigger warning before this commit:

    options(warnPartialMatchArgs=TRUE)
    con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
    DBI::dbWriteTable(con, "mtcars", mtcars)