### PR TITLE
Add usage of SQL to sqlInterpolate examples

### DIFF
--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -17,7 +17,8 @@ NULL
 #' @param ...,.dots Named values (for `...`) or a named list (for `.dots`)
 #'   to interpolate into a string. All strings
 #'   will be first escaped with [dbQuoteString()] prior
-#'   to interpolation to protect against SQL injection attacks.
+#'   to interpolation to protect against SQL injection attacks
+#'   unless specified by [SQL()].
 #' @export
 #' @examples
 #' sql <- "SELECT * FROM X WHERE name = ?name"
@@ -25,6 +26,13 @@ NULL
 #'
 #' # This is safe because the single quote has been double escaped
 #' sqlInterpolate(ANSI(), sql, name = "H'); DROP TABLE--;")
+#'
+#' # Use SQL() to avoid escaping
+#' sql2 <- "SELECT * FROM ?table WHERE name in ?names"
+#' sqlInterpolate(ANSI(), sql2, table = SQL("X"), names = SQL("('a','b')"))
+#'
+#' # but it is unsafe
+#' sqlInterpolate(ANSI(), sql2, table = SQL("X; DELETE FROM X; SELECT * FROM X"), names = SQL("('a','b')"))
 setGeneric("sqlInterpolate",
   def = function(conn, sql, ..., .dots = list()) standardGeneric("sqlInterpolate")
 )

--- a/man/sqlInterpolate.Rd
+++ b/man/sqlInterpolate.Rd
@@ -17,7 +17,8 @@ by a letter, digit, \code{.} or \code{_}.}
 \item{..., .dots}{Named values (for \code{...}) or a named list (for \code{.dots})
 to interpolate into a string. All strings
 will be first escaped with \code{\link[=dbQuoteString]{dbQuoteString()}} prior
-to interpolation to protect against SQL injection attacks.}
+to interpolation to protect against SQL injection attacks
+unless specified by \code{\link[=SQL]{SQL()}}.}
 }
 \description{
 Safely interpolate values into an SQL string
@@ -36,4 +37,11 @@ sqlInterpolate(ANSI(), sql, name = "Hadley")
 
 # This is safe because the single quote has been double escaped
 sqlInterpolate(ANSI(), sql, name = "H'); DROP TABLE--;")
+
+# Use SQL() to avoid escaping
+sql2 <- "SELECT * FROM ?table WHERE name in ?names"
+sqlInterpolate(ANSI(), sql2, table = SQL("X"), names = SQL("('a','b')"))
+
+# but it is unsafe
+sqlInterpolate(ANSI(), sql2, table = SQL("X; DELETE FROM X; SELECT * FROM X"), names = SQL("('a','b')"))
 }

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -64,6 +64,13 @@ test_that("strings are quoted", {
   )
 })
 
+test_that("unquoted strings", {
+  expect_equal(
+    sqlInterpolate(ANSI(), "?a ?b", a = SQL("abc"), b = SQL("('a','b')")),
+    SQL("abc ('a','b')")
+  )
+})
+
 test_that("some more complex case works as well", {
   expect_equal(
     sqlInterpolate(ANSI(), "asdf ?faa /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' ?fuu -- ? ?bar", faa = "abc", fuu=42L),


### PR DESCRIPTION
This PR addresses #259 as @krlmlr suggests.

Examples of using `SQL()` to create unquoted strings are added to the documentation of `sqlInterpolate()`. A test case is added too.

Closes #259.