### PR TITLE
Support Id with catalog in dbUnquoteIdentifier

### DIFF
--- a/tests/testthat/test-quote.R
+++ b/tests/testthat/test-quote.R
@@ -23,3 +23,22 @@ test_that("SQL names", {
   expect_equal(names(SQL(letters, names = LETTERS)), LETTERS)
   expect_null(names(SQL(setNames(letters, LETTERS))))
 })
+
+test_that("unquote Id", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), Id(table = "a")), list(Id(table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), Id(table = "a", schema = "b")), list(Id(table = "a", schema = "b")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), Id(table = "a", schema = "b", catalog = "c")),
+               list(Id(table = "a", schema = "b", catalog = "c")))
+})
+
+test_that("unquote SQL", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL("a")), list(Id(table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"b"."a"')), list(Id(schema = "b", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
+               list(Id(catalog = "c", schema = "b", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
+               list(Id(catalog = "c", schema = "b", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL(c('"Catalog"."Schema"."Table"', '"UnqualifiedTable"'))),
+               list(Id(catalog = "Catalog", schema = "Schema", table = "Table"),
+                    Id(table = "UnqualifiedTable")))
+})


### PR DESCRIPTION
Extended dbUnquoteIdentifier to support Id objects with a catalog attribute. This issue was identified in, and partially resolves, [#175](https://github.com/r-dbi/odbc/issues/197). dbWriteTable will now succeed in non-default schema as long as the catalog is specified.