### PR TITLE
dbUnquoteIdentifier

### DIFF
--- a/tests/testthat/test-quote.R
+++ b/tests/testthat/test-quote.R
@@ -32,11 +32,13 @@ test_that("unquote Id", {
 })
 
 test_that("unquote SQL", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"a"')), list(Id(table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL("a")), list(Id(table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"b"."a"')), list(Id(schema = "b", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('b.a')), list(Id(schema = "b", table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
                list(Id(catalog = "c", schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('c.b.a')),
                list(Id(catalog = "c", schema = "b", table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL(c('"Catalog"."Schema"."Table"', '"UnqualifiedTable"'))),
                list(Id(catalog = "Catalog", schema = "Schema", table = "Table"),

--- a/tests/testthat/test-quote.R
+++ b/tests/testthat/test-quote.R
@@ -40,6 +40,10 @@ test_that("unquote SQL", {
                list(Id(catalog = "c", schema = "b", table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL('c.b.a')),
                list(Id(catalog = "c", schema = "b", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b.d"."a"')),
+               list(Id(catalog = "c", schema = "b.d", table = "a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('c."b""d".a')),
+               list(Id(catalog = "c", schema = 'b"d', table = "a")))
   expect_equal(dbUnquoteIdentifier(ANSI(), SQL(c('"Catalog"."Schema"."Table"', '"UnqualifiedTable"'))),
                list(Id(catalog = "Catalog", schema = "Schema", table = "Table"),
                     Id(table = "UnqualifiedTable")))


### PR DESCRIPTION
Modifies DBI::dbUnquoteIdentifier() to parse `catalog.schema.table` specifications without each component being enclosed by double-quotes, as required to work with dbplyr.

Fixes #277.