### PR TITLE
WIP: Add n argument to dbReadTable()

### DIFF
--- a/man/dbReadTable.Rd
+++ b/man/dbReadTable.Rd
@@ -4,7 +4,7 @@
 \alias{dbReadTable}
 \title{Copy data frames from database tables}
 \usage{
-dbReadTable(conn, name, ...)
+dbReadTable(conn, name, n = NULL, ...)
 }
 \arguments{
 \item{conn}{A \linkS4class{DBIConnection} object, as returned by
@@ -12,6 +12,8 @@ dbReadTable(conn, name, ...)
 
 \item{name}{A character string specifying the unquoted DBMS table name,
 or the result of a call to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}.}
+
+\item{n}{The number of rows to read, use \code{NULL} for "no limit".}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -83,9 +83,9 @@
 
 \S4method{dbListObjects}{DBIConnection}(conn, prefix = NULL, ...)
 
-\S4method{dbReadTable}{DBIConnection,character}(conn, name, ..., row.names = FALSE, check.names = TRUE)
+\S4method{dbReadTable}{DBIConnection,character}(conn, name, n = NULL, ..., row.names = FALSE, check.names = TRUE)
 
-\S4method{dbReadTable}{DBIConnection,Id}(conn, name, ...)
+\S4method{dbReadTable}{DBIConnection,Id}(conn, name, n = NULL, ...)
 
 \S4method{dbWriteTable}{DBIConnection,Id}(conn, name, value, ...)
 


### PR DESCRIPTION
Postponing, because if we limit rows we also might want to limit columns. This functionality already exists in much better form in dbplyr and other packages.

Closes #240.