### PR TITLE
Resolves #329

### DIFF
--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -278,7 +278,7 @@ sqlParseVariablesImpl <- function(sql, quotes, comments) {
         comment_end_arr <- comments[[comment_spec_offset]][["end"]]
         comment_end_length <- length(comment_end_arr)
         if (identical(sql_arr[i:(i + comment_end_length - 1L)], comment_end_arr)) {
-          i <- i + comment_end_length
+          i <- i + (comment_end_length - 1)
           comment_spec_offset <- 0L
           state <- "default"
         }

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -114,6 +114,10 @@ test_that("corner cases work", {
     sqlInterpolate(ANSI(), "--"),
     SQL("--")
   )
+  expect_equal(
+    sqlInterpolate(ANSI(), "SELECT *\n--comment\n--consecutive comment with '\nFROM mytable"),
+    SQL("SELECT *\n--comment\n--consecutive comment with '\nFROM mytable")
+  )
   expect_error(
     sqlInterpolate(ANSI(), "/*"),
     "Unterminated comment"


### PR DESCRIPTION
Resolves an off-by-one error in `sqlParseVariablesImpl` that caused `sqlInterpolate` to miss consecutive comments (#329).

This results in an error when the second consecutive comment contains what would otherwise be an unterminated string literal (e.g. a single quote character in the second consecutive comment). But I suspect it could also cause `sqlInterpolate` to behave unexpectedly in other ways.

Also adds a test for the first specific example cited in #329.
