### PR TITLE
Add error message for empty input

### DIFF
--- a/R/table-insert.R
+++ b/R/table-insert.R
@@ -70,9 +70,13 @@ setMethod("sqlAppendTable", signature("DBIConnection"),
 #' sqlAppendTableTemplate(ANSI(), "mtcars", mtcars, row.names = FALSE)
 sqlAppendTableTemplate <- function(con, table, values, row.names = NA, prefix = "?", ..., pattern = "") {
   if (missing(row.names)) {
-    warning("Do not rely on the default value of the row.names argument for sqlAppendTableTemplate(), it will change in the future.",
+    warning("Do not rely on the default value of the `row.names` argument to `sqlAppendTableTemplate()`, it will change in the future.",
       call. = FALSE
     )
+  }
+
+  if (length(values) == 0) {
+    stop("Must pass at least one column in `values`", call. = FALSE)
   }
 
   table <- dbQuoteIdentifier(con, table)


### PR DESCRIPTION
Zero-row data frames already work.

Closes #313.

``` r
library(DBI)
db <- dbConnect(RSQLite::SQLite(), ":memory:")
dbExecute(db, "create table T(n  integer primary key)")
#> [1] 0
dbAppendTable(db, "T", data.frame())
#> Error: Must pass at least one column in `values`
```

<sup>Created on 2021-01-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>