### PR TITLE
Fix valueClass for dbSendQueryStream()

### DIFF
--- a/R/dbSendQueryStream.R
+++ b/R/dbSendQueryStream.R
@@ -15,5 +15,5 @@ setGeneric("dbSendQueryStream",
     require_arrow()
     standardGeneric("dbSendQueryStream")
   },
-  valueClass = "DBIResultStream"
+  valueClass = "DBIResult"
 )


### PR DESCRIPTION
We don't want to expect users (such as duckdb) to inherit from `DBIResultStream`, which is a class internal to DBI.