### PR TITLE
feat: `dbUnquoteIdentifier()` creates `Id()` objects without component names

### DIFF
--- a/R/dbUnquoteIdentifier.R
+++ b/R/dbUnquoteIdentifier.R
@@ -26,13 +26,9 @@
 #'
 #' # The returned object is always a list,
 #' # also for Id objects
-#' dbUnquoteIdentifier(
-#'   ANSI(),
-#'   Id(catalog = "Catalog", schema = "Schema", table = "Table")
-#' )
+#' dbUnquoteIdentifier(ANSI(), Id("Catalog", "Schema", "Table"))
 #'
-#' # Quoting is the inverse operation to unquoting the elements
-#' # of the returned list
+#' # Quoting and unquoting are inverses
 #' dbQuoteIdentifier(
 #'   ANSI(),
 #'   dbUnquoteIdentifier(ANSI(), SQL("UnqualifiedTable"))[[1]]
@@ -40,7 +36,7 @@
 #'
 #' dbQuoteIdentifier(
 #'   ANSI(),
-#'   dbUnquoteIdentifier(ANSI(), Id(schema = "Schema", table = "Table"))[[1]]
+#'   dbUnquoteIdentifier(ANSI(), Id("Schema", "Table"))[[1]]
 #' )
 setGeneric("dbUnquoteIdentifier",
   def = function(conn, x, ...) standardGeneric("dbUnquoteIdentifier")

--- a/man/dbClearResult.Rd
+++ b/man/dbClearResult.Rd
@@ -13,8 +13,9 @@ dbClearResult(res, ...)
 }
 \value{
 \code{dbClearResult()} returns \code{TRUE}, invisibly, for result sets obtained from
-both \code{dbSendQuery()}
-and \code{dbSendStatement()}.
+\code{dbSendQuery()},
+\code{dbSendStatement()},
+or \code{dbSendQueryArrow()},
 }
 \description{
 Frees all resources (local and remote) associated with a result set.
@@ -92,7 +93,9 @@ to ensure that this step is always executed.
 
 
 An attempt to close an already closed result set issues a warning
-in both cases.
+for \code{dbSendQuery()},
+\code{dbSendStatement()},
+and \code{dbSendQueryArrow()},
 
 }
 

--- a/man/dbClearResult.Rd
+++ b/man/dbClearResult.Rd
@@ -13,9 +13,8 @@ dbClearResult(res, ...)
 }
 \value{
 \code{dbClearResult()} returns \code{TRUE}, invisibly, for result sets obtained from
-\code{dbSendQuery()},
-\code{dbSendStatement()},
-or \code{dbSendQueryArrow()},
+both \code{dbSendQuery()}
+and \code{dbSendStatement()}.
 }
 \description{
 Frees all resources (local and remote) associated with a result set.
@@ -93,9 +92,7 @@ to ensure that this step is always executed.
 
 
 An attempt to close an already closed result set issues a warning
-for \code{dbSendQuery()},
-\code{dbSendStatement()},
-and \code{dbSendQueryArrow()},
+in both cases.
 
 }
 

--- a/man/dbUnquoteIdentifier.Rd
+++ b/man/dbUnquoteIdentifier.Rd
@@ -73,13 +73,9 @@ dbUnquoteIdentifier(
 
 # The returned object is always a list,
 # also for Id objects
-dbUnquoteIdentifier(
-  ANSI(),
-  Id(catalog = "Catalog", schema = "Schema", table = "Table")
-)
+dbUnquoteIdentifier(ANSI(), Id("Catalog", "Schema", "Table"))
 
-# Quoting is the inverse operation to unquoting the elements
-# of the returned list
+# Quoting and unquoting are inverses
 dbQuoteIdentifier(
   ANSI(),
   dbUnquoteIdentifier(ANSI(), SQL("UnqualifiedTable"))[[1]]
@@ -87,7 +83,7 @@ dbQuoteIdentifier(
 
 dbQuoteIdentifier(
   ANSI(),
-  dbUnquoteIdentifier(ANSI(), Id(schema = "Schema", table = "Table"))[[1]]
+  dbUnquoteIdentifier(ANSI(), Id("Schema", "Table"))[[1]]
 )
 }
 \seealso{

--- a/tests/testthat/test-dbUnquoteIdentifier_DBIConnection.R
+++ b/tests/testthat/test-dbUnquoteIdentifier_DBIConnection.R
@@ -1,0 +1,20 @@
+test_that("can unquote any number of components", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), "a"), list(Id("a")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), "a.b"), list(Id("a", "b")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), "a.b.c"), list(Id("a", "b", "c")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), "a.b.c.d"), list(Id("a", "b", "c", "d")))
+})
+
+test_that("can unquote any quoted components", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), '"a.b"'), list(Id("a.b")))
+
+  expect_equal(dbUnquoteIdentifier(ANSI(), 'a."b"'), list(Id("a", "b")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), '"a".b'), list(Id("a", "b")))
+  expect_equal(dbUnquoteIdentifier(ANSI(), '"a"."b"'), list(Id("a", "b")))
+
+  expect_equal(dbUnquoteIdentifier(ANSI(), '"a"""."b"""'), list(Id('a"', 'b"')))
+})
+
+test_that("Id is unchanged and wrapped in list", {
+  expect_equal(dbUnquoteIdentifier(ANSI(), Id("foo")), list(Id("foo")))
+})

--- a/tests/testthat/test-quote.R
+++ b/tests/testthat/test-quote.R
@@ -28,23 +28,3 @@ test_that("unquote Id", {
   expect_equal(dbUnquoteIdentifier(ANSI(), Id(table = "a", schema = "b", catalog = "c")),
     list(Id(table = "a", schema = "b", catalog = "c")))
 })
-
-test_that("unquote SQL", {
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"a"')), list(Id(table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL("a")), list(Id(table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"b"."a"')), list(Id(schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL("b.a")), list(Id(schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
-    list(Id(catalog = "c", schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b"."a"')),
-    list(Id(catalog = "c", schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL("c.b.a")),
-    list(Id(catalog = "c", schema = "b", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('"c"."b.d"."a"')),
-    list(Id(catalog = "c", schema = "b.d", table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL('c."b""d".a')),
-    list(Id(catalog = "c", schema = 'b"d', table = "a")))
-  expect_equal(dbUnquoteIdentifier(ANSI(), SQL(c('"Catalog"."Schema"."Table"', '"UnqualifiedTable"'))),
-    list(Id(catalog = "Catalog", schema = "Schema", table = "Table"),
-      Id(table = "UnqualifiedTable")))
-})


### PR DESCRIPTION
Fixes #421