### PR TITLE
feat: Arrange the `DBI::Id()` object in SQL order

### DIFF
--- a/R/00-Id.R
+++ b/R/00-Id.R
@@ -66,6 +66,6 @@ orderIdParams <- function(..., database = NULL,
     catalog = catalog,
     schema = schema,
     ...,
-    table = table)
-
+    table = table
+  )
 }

--- a/R/00-Id.R
+++ b/R/00-Id.R
@@ -59,34 +59,14 @@ dbQuoteIdentifier_DBIConnection_Id <- function(conn, x, ...) {
 }
 
 
-#' Order DBI::Id() user inputs
-#'
-#' Create the specific order:
-#' catalog > cluster > schema > table
-#'
-#' @param ... table param and unnamed `Id` components
-#' @param database optional database `Id` component
-#' @param catalog optional catalog `Id` component
-#' @param cluster optional cluster `Id` component
-#' @param schema optional schema `Id` component
-#' @param table optional table `Id` component
-#'
-#' @return vector of user's inputs, with names if specified, in correct SQL order
-#'
-#' @examples
-#' DBI:::orderIdParams(table = "flights", schema = "nycflights13", 'unnamed_id')
-#' DBI:::orderIdParams("nycflights13", "flights")
-#'
 orderIdParams <- function(..., database = NULL,
                           catalog = NULL, cluster = NULL,
                           schema = NULL, table = NULL){
-  c(
-    database = database,
+  c(database = database,
     cluster = cluster,
     catalog = catalog,
     schema = schema,
     ...,
-    table = table
-    )
+    table = table)
 
 }

--- a/R/00-Id.R
+++ b/R/00-Id.R
@@ -80,14 +80,13 @@ dbQuoteIdentifier_DBIConnection_Id <- function(conn, x, ...) {
 orderIdParams <- function(..., database = NULL,
                           catalog = NULL, cluster = NULL,
                           schema = NULL, table = NULL){
-
-  list(
+  c(
     database = database,
     cluster = cluster,
     catalog = catalog,
     schema = schema,
     ...,
     table = table
-  ) |> unlist()
+    )
 
 }

--- a/R/00-Id.R
+++ b/R/00-Id.R
@@ -28,7 +28,7 @@ setClass("Id", slots = list(name = "character"))
 #' @examples
 #' # Identifies a table in a specific schema:
 #' Id("dbo", "Customer")
-#' # You can name the components to ensure a correct output order,
+#' # You can name the components to order `Id()` output,
 #' #  but names are not required, e.g:
 #' Id(table = "Customer", schema = "dbo")
 #'
@@ -40,9 +40,7 @@ setClass("Id", slots = list(name = "character"))
 #' dbWriteTable(con, Id("myschema", "mytable"), data.frame(a = 1))
 #' }
 Id <- function(...) {
-
   components <- orderIdParams(...)
-
   if (!is.character(components)) {
     stop("All elements of `...` must be strings.", call. = FALSE)
   }

--- a/R/00-Id.R
+++ b/R/00-Id.R
@@ -22,14 +22,13 @@ setClass("Id", slots = list(name = "character"))
 #' Objects of this class are also returned from [dbListObjects()].
 #'
 #' @param ... Components of the hierarchy, e.g. `cluster`,
-#'  `catalog`, `schema`, `table`, depending on the database backend. For more
+#'  `catalog`, `schema`, or `table`, depending on the database backend. For more
 #'  on these concepts, see <https://stackoverflow.com/questions/7022755/>
 #' @export
 #' @examples
 #' # Identifies a table in a specific schema:
 #' Id("dbo", "Customer")
-#' # You can name the components to order `Id()` output,
-#' #  but names are not required, e.g:
+#' # You can name the components if you want, but it's not needed
 #' Id(table = "Customer", schema = "dbo")
 #'
 #' # Create a SQL expression for an identifier:
@@ -45,7 +44,7 @@ Id <- function(...) {
     stop("All elements of `...` must be strings.", call. = FALSE)
   }
 
-  methods::new("Id", name = components)
+  new("Id", name = components)
 }
 
 #' @export

--- a/tests/testthat/test-00-Id.R
+++ b/tests/testthat/test-00-Id.R
@@ -1,14 +1,26 @@
 test_that("Id() requires a character vector", {
-  expect_snapshot(Id(1), error = TRUE)
+  expect_error(Id(1))
 })
 
 test_that("has a decent print method", {
-  expect_snapshot(Id("a", "b"))
+  expect_equal(
+    utils::capture.output(Id(schema = "a", table = "b")),
+    "<Id> \"a\".\"b\""
+  )
 })
 
 test_that("each element is quoted individually", {
   expect_equal(
-    DBI::dbQuoteIdentifier(ANSI(), Id("a", "b.c")),
+    dbQuoteIdentifier(ANSI(), Id("a", "b.c")),
     SQL('"a"."b.c"')
   )
+})
+
+test_that("Id organizes standard named elements", {
+ expect_equal(
+   dbQuoteIdentifier(ANSI(), Id("unnamed",
+                                table = "last", schema = "3rd",
+                                cluster = '1st', catalog = "2nd")),
+   SQL('"1st"."2nd"."3rd"."unnamed"."last"')
+ )
 })

--- a/tests/testthat/test-00-Id.R
+++ b/tests/testthat/test-00-Id.R
@@ -16,7 +16,7 @@ test_that("each element is quoted individually", {
   )
 })
 
-test_that("Id organizes standard named elements", {
+test_that("Id organizes the standard named elements", {
  expect_equal(
    dbQuoteIdentifier(ANSI(), Id("unnamed",
                                 table = "last", schema = "3rd",

--- a/tests/testthat/test-00-Id.R
+++ b/tests/testthat/test-00-Id.R
@@ -3,15 +3,12 @@ test_that("Id() requires a character vector", {
 })
 
 test_that("has a decent print method", {
-  expect_equal(
-    utils::capture.output(Id(schema = "a", table = "b")),
-    "<Id> \"a\".\"b\""
-  )
+  expect_snapshot(Id("a", "b"))
 })
 
 test_that("each element is quoted individually", {
   expect_equal(
-    dbQuoteIdentifier(ANSI(), Id("a", "b.c")),
+    DBI::dbQuoteIdentifier(ANSI(), Id("a", "b.c")),
     SQL('"a"."b.c"')
   )
 })

--- a/tests/testthat/test-00-Id.R
+++ b/tests/testthat/test-00-Id.R
@@ -1,5 +1,5 @@
 test_that("Id() requires a character vector", {
-  expect_error(Id(1))
+  expect_snapshot(Id(1), error = TRUE)
 })
 
 test_that("has a decent print method", {
@@ -24,3 +24,12 @@ test_that("Id organizes the standard named elements", {
    SQL('"1st"."2nd"."3rd"."unnamed"."last"')
  )
 })
+
+test_that("Id organizes mingled named and unnamed elements; ignores NULL", {
+  expect_equal(
+    dbQuoteIdentifier(ANSI(), Id(
+      table = "4", some_ref = '2', "3", catalog = "1", cluster = NULL)),
+    SQL('"1"."2"."3"."4"')
+  )
+})
+


### PR DESCRIPTION
My package uses `DBI::Id()` to write out SQL via `dbQuoteIdentifier()`, but success or failure of the SQL statement depends on the order that users input the Id params. In my package, I overwrote the `Id()` function to create a similar DBI object, but this issue appears to have been a problem for others as well. 

Changes correct my issue, which is identical to this closed issue:
https://github.com/r-dbi/odbc/issues/214

Might fix this user's issue:
https://github.com/r-dbi/DBI/issues/426
