### PR TITLE
fix: `dbQuoteLiteral()` uses exponential notation for numeric values

### DIFF
--- a/R/dbQuoteLiteral_DBIConnection.R
+++ b/R/dbQuoteLiteral_DBIConnection.R
@@ -48,8 +48,14 @@ dbQuoteLiteral_DBIConnection <- function(conn, x, ...) {
     return(SQL(blob_data, names = names(x)))
   }
 
+  if (is.double(x)) {
+    out <- sprintf("%.17e", x)
+    out[is.na(x)] <- "NULL"
+    return(SQL(out, names = names(x)))
+  }
+
   if (is.logical(x)) {
-    x <- as.numeric(x)
+    x <- as.integer(x)
   }
 
   x <- as.character(x)

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -1,21 +1,21 @@
 test_that("parameter names matched", {
   expect_equal(
-    sqlInterpolate(ANSI(), "?a ?b", a = 1, b = 2),
+    sqlInterpolate(ANSI(), "?a ?b", a = 1L, b = 2L),
     SQL("1 2")
   )
 
   expect_equal(
-    sqlInterpolate(ANSI(), "?a ?b", b = 2, a = 1),
+    sqlInterpolate(ANSI(), "?a ?b", b = 2L, a = 1L),
     SQL("1 2")
   )
 
   expect_equal(
-    sqlInterpolate(ANSI(), "?a ?b", b = 2, .dots = list(a = 1)),
+    sqlInterpolate(ANSI(), "?a ?b", b = 2L, .dots = list(a = 1L)),
     SQL("1 2")
   )
 
   expect_equal(
-    sqlInterpolate(ANSI(), "?a ?b", .dots = list(a = 1, b = 2)),
+    sqlInterpolate(ANSI(), "?a ?b", .dots = list(a = 1L, b = 2L)),
     SQL("1 2")
   )
 })
@@ -29,21 +29,21 @@ test_that("parameters in strings are ignored", {
 
 test_that("named parameters check matches", {
   expect_error(
-    sqlInterpolate(ANSI(), "?a ?b", a = 1, d = 2),
+    sqlInterpolate(ANSI(), "?a ?b", a = 1L, d = 2L),
     "Supplied values don't match named vars to interpolate"
   )
 })
 
 test_that("positional parameters work", {
   expect_equal(
-    sqlInterpolate(ANSI(), "a ? c ? d ", 1, 2),
+    sqlInterpolate(ANSI(), "a ? c ? d ", 1L, 2L),
     SQL("a 1 c 2 d ")
   )
 })
 
 test_that("positional parameters can't have names", {
   expect_error(
-    sqlInterpolate(ANSI(), "? ?", a = 1, 2),
+    sqlInterpolate(ANSI(), "? ?", a = 1L, 2),
     "Positional variables don't take named arguments"
   )
 })
@@ -78,7 +78,7 @@ test_that("some more complex case works as well", {
 
 test_that("escaping quotes with doubling works", {
   expect_equal(
-    sqlInterpolate(ANSI(), "'this is a single '' one ?quoted string' ?bar ", bar = 42),
+    sqlInterpolate(ANSI(), "'this is a single '' one ?quoted string' ?bar ", bar = 42L),
     SQL("'this is a single '' one ?quoted string' 42 ")
   )
 })
@@ -93,7 +93,7 @@ test_that("corner cases work", {
     "Supplied values don't match positional vars to interpolate"
   )
   expect_equal(
-    sqlInterpolate(ANSI(), "?a", a = 1),
+    sqlInterpolate(ANSI(), "?a", a = 1L),
     SQL("1")
   )
   expect_equal(
@@ -105,7 +105,7 @@ test_that("corner cases work", {
     "Unterminated literal"
   )
   expect_equal(
-    sqlInterpolate(ANSI(), "?a\"\"?b", a = 1, b = 2),
+    sqlInterpolate(ANSI(), "?a\"\"?b", a = 1L, b = 2L),
     SQL("1\"\"2")
   )
   expect_equal(

--- a/tests/testthat/test-sql-df.R
+++ b/tests/testthat/test-sql-df.R
@@ -6,6 +6,6 @@ test_that("NAs turn in NULLs", {
   )
   sql_df <- sqlData(ANSI(), df)
 
-  expect_equal(sql_df$x, SQL(c("1", "NULL")))
+  expect_equal(sql_df$x, SQL(c("1.00000000000000000e+00", "NULL")))
   expect_equal(sql_df$y, SQL(c("'a'", "NULL")))
 })


### PR DESCRIPTION
Closes #404.