### PR TITLE
fix: `dbQuoteLiteral()` uses the format `"%Y-%m-%d %H-%M-%S%z"` which is understood by more databases

### DIFF
--- a/R/dbQuoteLiteral_DBIConnection.R
+++ b/R/dbQuoteLiteral_DBIConnection.R
@@ -19,7 +19,7 @@ dbQuoteLiteral_DBIConnection <- function(conn, x, ...) {
   if (inherits(x, "POSIXt")) {
     return(dbQuoteString(
       conn,
-      strftime(as.POSIXct(x), "%Y%m%d%H%M%S", tz = "UTC")
+      strftime(as.POSIXct(x), "%Y-%m-%d %H-%M-%S%z")
     ))
   }
 


### PR DESCRIPTION
Closes #467.