### PR TITLE
docs: Avoid `\linkS4class{}` in documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
     arrow,
     blob,
     covr,
-    DBItest,
+    DBItest (>= 1.8.2),
     dbplyr,
     downlit,
     dplyr,

--- a/R/dbClearResult.R
+++ b/R/dbClearResult.R
@@ -14,7 +14,7 @@
 #' @inheritSection DBItest::spec_result_clear_result Failure modes
 #' @inheritSection DBItest::spec_result_clear_result Specification
 #'
-#' @param res An object inheriting from [DBIResult-class].
+#' @param res An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.
 #' @param ... Other arguments passed on to methods.
 #' @family DBIResult generics
 #' @family DBIResultArrow generics

--- a/R/dbClearResult.R
+++ b/R/dbClearResult.R
@@ -14,7 +14,7 @@
 #' @inheritSection DBItest::spec_result_clear_result Failure modes
 #' @inheritSection DBItest::spec_result_clear_result Specification
 #'
-#' @param res An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.
+#' @param res An object inheriting from [DBI::DBIResult][DBIResult-class].
 #' @param ... Other arguments passed on to methods.
 #' @family DBIResult generics
 #' @family DBIResultArrow generics

--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -14,8 +14,8 @@
 #' @inherit DBItest::spec_driver_connect return
 #' @inheritSection DBItest::spec_driver_connect Specification
 #'
-#' @param drv An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
-#'   or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
+#' @param drv An object that inherits from [DBI::DBIDriver][DBIDriver-class],
+#'   or an existing [DBI::DBIConnection][DBIConnection-class]
 #'   object (in order to clone an existing connection).
 #' @param ... Authentication arguments needed by the DBMS instance; these
 #'   typically include `user`, `password`, `host`, `port`, `dbname`, etc.

--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -14,10 +14,10 @@
 #' @inherit DBItest::spec_driver_connect return
 #' @inheritSection DBItest::spec_driver_connect Specification
 #'
-#' @param drv an object that inherits from [DBIDriver-class],
-#'   or an existing [DBIConnection-class]
+#' @param drv An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
+#'   or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 #'   object (in order to clone an existing connection).
-#' @param ... authentication arguments needed by the DBMS instance; these
+#' @param ... Authentication arguments needed by the DBMS instance; these
 #'   typically include `user`, `password`, `host`, `port`, `dbname`, etc.
 #'   For details see the appropriate `DBIDriver`.
 #' @seealso [dbDisconnect()] to disconnect from a database.

--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -27,8 +27,8 @@
 #' @inheritSection DBItest::spec_result_create_table_with_data_type Specification
 #'
 #' @inheritParams dbListConnections
-#' @param dbObj A object inheriting from [DBIDriver-class]
-#'   or [DBIConnection-class]
+#' @param dbObj A object inheriting from \link[DBI:DBIDriver-class]{DBI::DBIDriver}
+#'   or \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 #' @param obj An R object whose SQL type we want to determine.
 #' @family DBIDriver generics
 #' @family DBIConnection generics

--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -27,8 +27,8 @@
 #' @inheritSection DBItest::spec_result_create_table_with_data_type Specification
 #'
 #' @inheritParams dbListConnections
-#' @param dbObj A object inheriting from \link[DBI:DBIDriver-class]{DBI::DBIDriver}
-#'   or \link[DBI:DBIConnection-class]{DBI::DBIConnection}
+#' @param dbObj A object inheriting from [DBI::DBIDriver][DBIDriver-class]
+#'   or [DBI::DBIConnection][DBIConnection-class]
 #' @param obj An R object whose SQL type we want to determine.
 #' @family DBIDriver generics
 #' @family DBIConnection generics

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -18,8 +18,8 @@
 #' @inheritSection DBItest::spec_result_fetch Specification
 #' @inheritSection DBItest::spec_result_roundtrip Specification
 #'
-#' @param res An object inheriting from [DBIResult-class], created by
-#'   [dbSendQuery()].
+#' @param res An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult},
+#'   created by [dbSendQuery()].
 #' @param n maximum number of records to retrieve per fetch. Use `n = -1`
 #'   or `n = Inf`
 #'   to retrieve all pending records.  Some implementations may recognize other

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -18,7 +18,7 @@
 #' @inheritSection DBItest::spec_result_fetch Specification
 #' @inheritSection DBItest::spec_result_roundtrip Specification
 #'
-#' @param res An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult},
+#' @param res An object inheriting from [DBI::DBIResult][DBIResult-class],
 #'   created by [dbSendQuery()].
 #' @param n maximum number of records to retrieve per fetch. Use `n = -1`
 #'   or `n = Inf`

--- a/R/dbFetchArrow.R
+++ b/R/dbFetchArrow.R
@@ -15,8 +15,8 @@
 #' @inheritSection DBItest::spec_arrow_fetch_arrow Failure modes
 #' @inheritSection DBItest::spec_arrow_fetch_arrow Specification
 #'
-#' @param res An object inheriting from [DBIResultArrow-class], created by
-#'   [dbSendQueryArrow()].
+#' @param res An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+#'    created by [dbSendQueryArrow()].
 #' @param ... Other arguments passed on to methods.
 #' @seealso Close the result set with [dbClearResult()] as soon as you
 #'   finish retrieving the records you want.

--- a/R/dbFetchArrow.R
+++ b/R/dbFetchArrow.R
@@ -15,7 +15,7 @@
 #' @inheritSection DBItest::spec_arrow_fetch_arrow Failure modes
 #' @inheritSection DBItest::spec_arrow_fetch_arrow Specification
 #'
-#' @param res An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+#' @param res An object inheriting from [DBI::DBIResultArrow][DBIResultArrow-class],
 #'    created by [dbSendQueryArrow()].
 #' @param ... Other arguments passed on to methods.
 #' @seealso Close the result set with [dbClearResult()] as soon as you

--- a/R/dbFetchArrowChunk.R
+++ b/R/dbFetchArrowChunk.R
@@ -16,7 +16,7 @@
 #' @inheritSection DBItest::spec_arrow_fetch_arrow_chunk Failure modes
 #' @inheritSection DBItest::spec_arrow_fetch_arrow_chunk Specification
 #'
-#' @param res An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+#' @param res An object inheriting from [DBI::DBIResultArrow][DBIResultArrow-class],
 #'   created by [dbSendQueryArrow()].
 #' @param ... Other arguments passed on to methods.
 #' @seealso Close the result set with [dbClearResult()] as soon as you

--- a/R/dbFetchArrowChunk.R
+++ b/R/dbFetchArrowChunk.R
@@ -16,8 +16,8 @@
 #' @inheritSection DBItest::spec_arrow_fetch_arrow_chunk Failure modes
 #' @inheritSection DBItest::spec_arrow_fetch_arrow_chunk Specification
 #'
-#' @param res An object inheriting from [DBIResultArrow-class], created by
-#'   [dbSendQueryArrow()].
+#' @param res An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+#'   created by [dbSendQueryArrow()].
 #' @param ... Other arguments passed on to methods.
 #' @seealso Close the result set with [dbClearResult()] as soon as you
 #'   finish retrieving the records you want.

--- a/R/dbGetQuery.R
+++ b/R/dbGetQuery.R
@@ -34,8 +34,8 @@
 #' Subclasses should override this method only if they provide some sort of
 #' performance optimization.
 #'
-#' @param conn A [DBIConnection-class] object, as returned by
-#'   [dbConnect()].
+#' @param conn A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+#'   as returned by [dbConnect()].
 #' @param statement a character string containing SQL.
 #' @param ... Other parameters passed on to methods.
 #' @family DBIConnection generics

--- a/R/dbGetQuery.R
+++ b/R/dbGetQuery.R
@@ -34,7 +34,7 @@
 #' Subclasses should override this method only if they provide some sort of
 #' performance optimization.
 #'
-#' @param conn A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+#' @param conn A [DBI::DBIConnection][DBIConnection-class] object,
 #'   as returned by [dbConnect()].
 #' @param statement a character string containing SQL.
 #' @param ... Other parameters passed on to methods.

--- a/R/dbGetQueryArrow.R
+++ b/R/dbGetQueryArrow.R
@@ -38,7 +38,7 @@
 #' Subclasses should override this method only if they provide some sort of
 #' performance optimization.
 #'
-#' @param conn A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+#' @param conn A [DBI::DBIConnection][DBIConnection-class] object,
 #'   as returned by [dbConnect()].
 #' @param statement a character string containing SQL.
 #' @param ... Other parameters passed on to methods.

--- a/R/dbGetQueryArrow.R
+++ b/R/dbGetQueryArrow.R
@@ -38,8 +38,8 @@
 #' Subclasses should override this method only if they provide some sort of
 #' performance optimization.
 #'
-#' @param conn A [DBIConnection-class] object, as returned by
-#'   [dbConnect()].
+#' @param conn A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+#'   as returned by [dbConnect()].
 #' @param statement a character string containing SQL.
 #' @param ... Other parameters passed on to methods.
 #' @family DBIConnection generics

--- a/man/dbAppendTable.Rd
+++ b/man/dbAppendTable.Rd
@@ -7,8 +7,8 @@
 dbAppendTable(conn, name, value, ..., row.names = NULL)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbAppendTable.Rd
+++ b/man/dbAppendTable.Rd
@@ -7,7 +7,7 @@
 dbAppendTable(conn, name, value, ..., row.names = NULL)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbAppendTableArrow.Rd
+++ b/man/dbAppendTableArrow.Rd
@@ -7,8 +7,8 @@
 dbAppendTableArrow(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbAppendTableArrow.Rd
+++ b/man/dbAppendTableArrow.Rd
@@ -7,7 +7,7 @@
 dbAppendTableArrow(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbBind.Rd
+++ b/man/dbBind.Rd
@@ -10,7 +10,7 @@ dbBind(res, params, ...)
 dbBindArrow(res, params, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{params}{For \code{dbBind()}, a list of values, named or unnamed,
 or a data frame, with one element/column per query parameter.

--- a/man/dbBind.Rd
+++ b/man/dbBind.Rd
@@ -10,7 +10,7 @@ dbBind(res, params, ...)
 dbBindArrow(res, params, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{params}{For \code{dbBind()}, a list of values, named or unnamed,
 or a data frame, with one element/column per query parameter.

--- a/man/dbCallProc.Rd
+++ b/man/dbCallProc.Rd
@@ -7,8 +7,8 @@
 dbCallProc(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/dbCallProc.Rd
+++ b/man/dbCallProc.Rd
@@ -7,7 +7,7 @@
 dbCallProc(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/dbCanConnect.Rd
+++ b/man/dbCanConnect.Rd
@@ -7,8 +7,8 @@
 dbCanConnect(drv, ...)
 }
 \arguments{
-\item{drv}{An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
-or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
+\item{drv}{An object that inherits from \link[=DBIDriver-class]{DBI::DBIDriver},
+or an existing \link[=DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
 
 \item{...}{Authentication arguments needed by the DBMS instance; these

--- a/man/dbCanConnect.Rd
+++ b/man/dbCanConnect.Rd
@@ -7,11 +7,11 @@
 dbCanConnect(drv, ...)
 }
 \arguments{
-\item{drv}{an object that inherits from \linkS4class{DBIDriver},
-or an existing \linkS4class{DBIConnection}
+\item{drv}{An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
+or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
 
-\item{...}{authentication arguments needed by the DBMS instance; these
+\item{...}{Authentication arguments needed by the DBMS instance; these
 typically include \code{user}, \code{password}, \code{host}, \code{port}, \code{dbname}, etc.
 For details see the appropriate \code{DBIDriver}.}
 }

--- a/man/dbClearResult.Rd
+++ b/man/dbClearResult.Rd
@@ -7,7 +7,7 @@
 dbClearResult(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbClearResult.Rd
+++ b/man/dbClearResult.Rd
@@ -7,7 +7,7 @@
 dbClearResult(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbColumnInfo.Rd
+++ b/man/dbColumnInfo.Rd
@@ -7,7 +7,7 @@
 dbColumnInfo(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbColumnInfo.Rd
+++ b/man/dbColumnInfo.Rd
@@ -7,7 +7,7 @@
 dbColumnInfo(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbConnect.Rd
+++ b/man/dbConnect.Rd
@@ -7,8 +7,8 @@
 dbConnect(drv, ...)
 }
 \arguments{
-\item{drv}{An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
-or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
+\item{drv}{An object that inherits from \link[=DBIDriver-class]{DBI::DBIDriver},
+or an existing \link[=DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
 
 \item{...}{Authentication arguments needed by the DBMS instance; these

--- a/man/dbConnect.Rd
+++ b/man/dbConnect.Rd
@@ -7,11 +7,11 @@
 dbConnect(drv, ...)
 }
 \arguments{
-\item{drv}{an object that inherits from \linkS4class{DBIDriver},
-or an existing \linkS4class{DBIConnection}
+\item{drv}{An object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
+or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
 
-\item{...}{authentication arguments needed by the DBMS instance; these
+\item{...}{Authentication arguments needed by the DBMS instance; these
 typically include \code{user}, \code{password}, \code{host}, \code{port}, \code{dbname}, etc.
 For details see the appropriate \code{DBIDriver}.}
 }

--- a/man/dbCreateTable.Rd
+++ b/man/dbCreateTable.Rd
@@ -7,8 +7,8 @@
 dbCreateTable(conn, name, fields, ..., row.names = NULL, temporary = FALSE)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbCreateTable.Rd
+++ b/man/dbCreateTable.Rd
@@ -7,7 +7,7 @@
 dbCreateTable(conn, name, fields, ..., row.names = NULL, temporary = FALSE)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbCreateTableArrow.Rd
+++ b/man/dbCreateTableArrow.Rd
@@ -7,8 +7,8 @@
 dbCreateTableArrow(conn, name, value, ..., temporary = FALSE)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbCreateTableArrow.Rd
+++ b/man/dbCreateTableArrow.Rd
@@ -7,7 +7,7 @@
 dbCreateTableArrow(conn, name, value, ..., temporary = FALSE)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbDataType.Rd
+++ b/man/dbDataType.Rd
@@ -7,8 +7,8 @@
 dbDataType(dbObj, obj, ...)
 }
 \arguments{
-\item{dbObj}{A object inheriting from \linkS4class{DBIDriver}
-or \linkS4class{DBIConnection}}
+\item{dbObj}{A object inheriting from \link[DBI:DBIDriver-class]{DBI::DBIDriver}
+or \link[DBI:DBIConnection-class]{DBI::DBIConnection}}
 
 \item{obj}{An R object whose SQL type we want to determine.}
 

--- a/man/dbDataType.Rd
+++ b/man/dbDataType.Rd
@@ -7,8 +7,8 @@
 dbDataType(dbObj, obj, ...)
 }
 \arguments{
-\item{dbObj}{A object inheriting from \link[DBI:DBIDriver-class]{DBI::DBIDriver}
-or \link[DBI:DBIConnection-class]{DBI::DBIConnection}}
+\item{dbObj}{A object inheriting from \link[=DBIDriver-class]{DBI::DBIDriver}
+or \link[=DBIConnection-class]{DBI::DBIConnection}}
 
 \item{obj}{An R object whose SQL type we want to determine.}
 

--- a/man/dbDisconnect.Rd
+++ b/man/dbDisconnect.Rd
@@ -7,8 +7,8 @@
 dbDisconnect(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/dbDisconnect.Rd
+++ b/man/dbDisconnect.Rd
@@ -7,7 +7,7 @@
 dbDisconnect(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/dbExecute.Rd
+++ b/man/dbExecute.Rd
@@ -7,8 +7,8 @@
 dbExecute(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbExecute.Rd
+++ b/man/dbExecute.Rd
@@ -7,7 +7,7 @@
 dbExecute(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbExistsTable.Rd
+++ b/man/dbExistsTable.Rd
@@ -7,7 +7,7 @@
 dbExistsTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbExistsTable.Rd
+++ b/man/dbExistsTable.Rd
@@ -7,8 +7,8 @@
 dbExistsTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbFetch.Rd
+++ b/man/dbFetch.Rd
@@ -10,8 +10,8 @@ dbFetch(res, n = -1, ...)
 fetch(res, n = -1, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}, created by
-\code{\link[=dbSendQuery]{dbSendQuery()}}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult},
+created by \code{\link[=dbSendQuery]{dbSendQuery()}}.}
 
 \item{n}{maximum number of records to retrieve per fetch. Use \code{n = -1}
 or \code{n = Inf}

--- a/man/dbFetch.Rd
+++ b/man/dbFetch.Rd
@@ -10,7 +10,7 @@ dbFetch(res, n = -1, ...)
 fetch(res, n = -1, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult},
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult},
 created by \code{\link[=dbSendQuery]{dbSendQuery()}}.}
 
 \item{n}{maximum number of records to retrieve per fetch. Use \code{n = -1}

--- a/man/dbFetchArrow.Rd
+++ b/man/dbFetchArrow.Rd
@@ -7,7 +7,7 @@
 dbFetchArrow(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+\item{res}{An object inheriting from \link[=DBIResultArrow-class]{DBI::DBIResultArrow},
 created by \code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
 
 \item{...}{Other arguments passed on to methods.}

--- a/man/dbFetchArrow.Rd
+++ b/man/dbFetchArrow.Rd
@@ -7,8 +7,8 @@
 dbFetchArrow(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResultArrow}, created by
-\code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
+\item{res}{An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+created by \code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbFetchArrowChunk.Rd
+++ b/man/dbFetchArrowChunk.Rd
@@ -7,7 +7,7 @@
 dbFetchArrowChunk(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+\item{res}{An object inheriting from \link[=DBIResultArrow-class]{DBI::DBIResultArrow},
 created by \code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
 
 \item{...}{Other arguments passed on to methods.}

--- a/man/dbFetchArrowChunk.Rd
+++ b/man/dbFetchArrowChunk.Rd
@@ -7,8 +7,8 @@
 dbFetchArrowChunk(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResultArrow}, created by
-\code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
+\item{res}{An object inheriting from \link[DBI:DBIResultArrow-class]{DBI::DBIResultArrow},
+created by \code{\link[=dbSendQueryArrow]{dbSendQueryArrow()}}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetException.Rd
+++ b/man/dbGetException.Rd
@@ -7,8 +7,8 @@
 dbGetException(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/dbGetException.Rd
+++ b/man/dbGetException.Rd
@@ -7,7 +7,7 @@
 dbGetException(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/dbGetQuery.Rd
+++ b/man/dbGetQuery.Rd
@@ -7,7 +7,7 @@
 dbGetQuery(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbGetQuery.Rd
+++ b/man/dbGetQuery.Rd
@@ -7,8 +7,8 @@
 dbGetQuery(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbGetQueryArrow.Rd
+++ b/man/dbGetQueryArrow.Rd
@@ -7,8 +7,8 @@
 dbGetQueryArrow(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbGetQueryArrow.Rd
+++ b/man/dbGetQueryArrow.Rd
@@ -7,7 +7,7 @@
 dbGetQueryArrow(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbGetRowCount.Rd
+++ b/man/dbGetRowCount.Rd
@@ -7,7 +7,7 @@
 dbGetRowCount(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetRowCount.Rd
+++ b/man/dbGetRowCount.Rd
@@ -7,7 +7,7 @@
 dbGetRowCount(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetRowsAffected.Rd
+++ b/man/dbGetRowsAffected.Rd
@@ -7,7 +7,7 @@
 dbGetRowsAffected(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetRowsAffected.Rd
+++ b/man/dbGetRowsAffected.Rd
@@ -7,7 +7,7 @@
 dbGetRowsAffected(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetStatement.Rd
+++ b/man/dbGetStatement.Rd
@@ -7,7 +7,7 @@
 dbGetStatement(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbGetStatement.Rd
+++ b/man/dbGetStatement.Rd
@@ -7,7 +7,7 @@
 dbGetStatement(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbHasCompleted.Rd
+++ b/man/dbHasCompleted.Rd
@@ -7,7 +7,7 @@
 dbHasCompleted(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbHasCompleted.Rd
+++ b/man/dbHasCompleted.Rd
@@ -7,7 +7,7 @@
 dbHasCompleted(res, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{...}{Other arguments passed on to methods.}
 }

--- a/man/dbListFields.Rd
+++ b/man/dbListFields.Rd
@@ -7,8 +7,8 @@
 dbListFields(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbListFields.Rd
+++ b/man/dbListFields.Rd
@@ -7,7 +7,7 @@
 dbListFields(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbListObjects.Rd
+++ b/man/dbListObjects.Rd
@@ -7,8 +7,8 @@
 dbListObjects(conn, prefix = NULL, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{prefix}{A fully qualified path in the database's namespace, or \code{NULL}.
 This argument will be processed with \code{\link[=dbUnquoteIdentifier]{dbUnquoteIdentifier()}}.

--- a/man/dbListObjects.Rd
+++ b/man/dbListObjects.Rd
@@ -7,7 +7,7 @@
 dbListObjects(conn, prefix = NULL, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{prefix}{A fully qualified path in the database's namespace, or \code{NULL}.

--- a/man/dbListResults.Rd
+++ b/man/dbListResults.Rd
@@ -7,7 +7,7 @@
 dbListResults(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/dbListResults.Rd
+++ b/man/dbListResults.Rd
@@ -7,8 +7,8 @@
 dbListResults(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/dbListTables.Rd
+++ b/man/dbListTables.Rd
@@ -7,8 +7,8 @@
 dbListTables(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }

--- a/man/dbListTables.Rd
+++ b/man/dbListTables.Rd
@@ -7,7 +7,7 @@
 dbListTables(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/dbQuoteIdentifier.Rd
+++ b/man/dbQuoteIdentifier.Rd
@@ -7,7 +7,7 @@
 dbQuoteIdentifier(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A character vector, \link{SQL} or \link{Id} object to quote as identifier.}

--- a/man/dbQuoteIdentifier.Rd
+++ b/man/dbQuoteIdentifier.Rd
@@ -7,8 +7,8 @@
 dbQuoteIdentifier(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A character vector, \link{SQL} or \link{Id} object to quote as identifier.}
 

--- a/man/dbQuoteLiteral.Rd
+++ b/man/dbQuoteLiteral.Rd
@@ -7,8 +7,8 @@
 dbQuoteLiteral(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A vector to quote as string.}
 

--- a/man/dbQuoteLiteral.Rd
+++ b/man/dbQuoteLiteral.Rd
@@ -7,7 +7,7 @@
 dbQuoteLiteral(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A vector to quote as string.}

--- a/man/dbQuoteString.Rd
+++ b/man/dbQuoteString.Rd
@@ -7,7 +7,7 @@
 dbQuoteString(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A character vector to quote as string.}

--- a/man/dbQuoteString.Rd
+++ b/man/dbQuoteString.Rd
@@ -7,8 +7,8 @@
 dbQuoteString(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{A character vector to quote as string.}
 

--- a/man/dbReadTable.Rd
+++ b/man/dbReadTable.Rd
@@ -7,8 +7,8 @@
 dbReadTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbReadTable.Rd
+++ b/man/dbReadTable.Rd
@@ -7,7 +7,7 @@
 dbReadTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbReadTableArrow.Rd
+++ b/man/dbReadTableArrow.Rd
@@ -7,8 +7,8 @@
 dbReadTableArrow(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbReadTableArrow.Rd
+++ b/man/dbReadTableArrow.Rd
@@ -7,7 +7,7 @@
 dbReadTableArrow(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbRemoveTable.Rd
+++ b/man/dbRemoveTable.Rd
@@ -7,7 +7,7 @@
 dbRemoveTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbRemoveTable.Rd
+++ b/man/dbRemoveTable.Rd
@@ -7,8 +7,8 @@
 dbRemoveTable(conn, name, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbSendQuery.Rd
+++ b/man/dbSendQuery.Rd
@@ -7,7 +7,7 @@
 dbSendQuery(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbSendQuery.Rd
+++ b/man/dbSendQuery.Rd
@@ -7,8 +7,8 @@
 dbSendQuery(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbSendQueryArrow.Rd
+++ b/man/dbSendQueryArrow.Rd
@@ -7,8 +7,8 @@
 dbSendQueryArrow(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbSendQueryArrow.Rd
+++ b/man/dbSendQueryArrow.Rd
@@ -7,7 +7,7 @@
 dbSendQueryArrow(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbSendStatement.Rd
+++ b/man/dbSendStatement.Rd
@@ -7,8 +7,8 @@
 dbSendStatement(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}
 

--- a/man/dbSendStatement.Rd
+++ b/man/dbSendStatement.Rd
@@ -7,7 +7,7 @@
 dbSendStatement(conn, statement, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{statement}{a character string containing SQL.}

--- a/man/dbSetDataMappings.Rd
+++ b/man/dbSetDataMappings.Rd
@@ -7,7 +7,7 @@
 dbSetDataMappings(res, flds, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
+\item{res}{An object inheriting from \link[=DBIResult-class]{DBI::DBIResult}.}
 
 \item{flds}{a field description object as returned by \code{dbColumnInfo}.}
 

--- a/man/dbSetDataMappings.Rd
+++ b/man/dbSetDataMappings.Rd
@@ -7,7 +7,7 @@
 dbSetDataMappings(res, flds, ...)
 }
 \arguments{
-\item{res}{An object inheriting from \linkS4class{DBIResult}.}
+\item{res}{An object inheriting from \link[DBI:DBIResult-class]{DBI::DBIResult}.}
 
 \item{flds}{a field description object as returned by \code{dbColumnInfo}.}
 

--- a/man/dbUnquoteIdentifier.Rd
+++ b/man/dbUnquoteIdentifier.Rd
@@ -7,8 +7,8 @@
 dbUnquoteIdentifier(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{An \link{SQL} or \link{Id} object.}
 

--- a/man/dbUnquoteIdentifier.Rd
+++ b/man/dbUnquoteIdentifier.Rd
@@ -7,7 +7,7 @@
 dbUnquoteIdentifier(conn, x, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{x}{An \link{SQL} or \link{Id} object.}

--- a/man/dbWithTransaction.Rd
+++ b/man/dbWithTransaction.Rd
@@ -11,8 +11,8 @@ dbWithTransaction(conn, code, ...)
 dbBreak()
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{code}{An arbitrary block of R code.}
 

--- a/man/dbWithTransaction.Rd
+++ b/man/dbWithTransaction.Rd
@@ -11,7 +11,7 @@ dbWithTransaction(conn, code, ...)
 dbBreak()
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{code}{An arbitrary block of R code.}

--- a/man/dbWriteTable.Rd
+++ b/man/dbWriteTable.Rd
@@ -7,7 +7,7 @@
 dbWriteTable(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/dbWriteTable.Rd
+++ b/man/dbWriteTable.Rd
@@ -7,8 +7,8 @@
 dbWriteTable(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbWriteTableArrow.Rd
+++ b/man/dbWriteTableArrow.Rd
@@ -7,8 +7,8 @@
 dbWriteTableArrow(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
 \itemize{

--- a/man/dbWriteTableArrow.Rd
+++ b/man/dbWriteTableArrow.Rd
@@ -7,7 +7,7 @@
 dbWriteTableArrow(conn, name, value, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{name}{The table name, passed on to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:

--- a/man/sqlInterpolate.Rd
+++ b/man/sqlInterpolate.Rd
@@ -7,7 +7,7 @@
 sqlInterpolate(conn, sql, ..., .dots = list())
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{sql}{A SQL string containing variables to interpolate.

--- a/man/sqlInterpolate.Rd
+++ b/man/sqlInterpolate.Rd
@@ -7,8 +7,8 @@
 sqlInterpolate(conn, sql, ..., .dots = list())
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{sql}{A SQL string containing variables to interpolate.
 Variables must start with a question mark and can be any valid R

--- a/man/transactions.Rd
+++ b/man/transactions.Rd
@@ -15,7 +15,7 @@ dbCommit(conn, ...)
 dbRollback(conn, ...)
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+\item{conn}{A \link[=DBIConnection-class]{DBI::DBIConnection} object,
 as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}

--- a/man/transactions.Rd
+++ b/man/transactions.Rd
@@ -15,8 +15,8 @@ dbCommit(conn, ...)
 dbRollback(conn, ...)
 }
 \arguments{
-\item{conn}{A \linkS4class{DBIConnection} object, as returned by
-\code{\link[=dbConnect]{dbConnect()}}.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object,
+as returned by \code{\link[=dbConnect]{dbConnect()}}.}
 
 \item{...}{Other parameters passed on to methods.}
 }


### PR DESCRIPTION
Workaround for https://github.com/r-lib/roxygen2/issues/1634.