### PR TITLE
dbWithTransaction: rollback on interrupt

### DIFF
--- a/R/dbWithTransaction_DBIConnection.R
+++ b/R/dbWithTransaction_DBIConnection.R
@@ -34,7 +34,8 @@ dbWithTransaction_DBIConnection <- function(conn, code) {
       res
     },
     dbi_abort = rollback_because,
-    error = rollback_because
+    error = rollback_because,
+    interrupt = rollback_because
   )
 }
 


### PR DESCRIPTION
currently in `dbWithTransaction`, if the execution is interrupted (Ctrl-C or Rstudio STOP button), then `dbRollback` never gets called. this pull request attempts to fix this. 