### PR TITLE
Document package connection lifetime

### DIFF
--- a/R/dbDisconnect.R
+++ b/R/dbDisconnect.R
@@ -9,6 +9,13 @@
 #' @inherit DBItest::spec_connection_disconnect return
 #' @inheritSection DBItest::spec_connection_disconnect Failure modes
 #'
+#' @section Connection lifetime in packages:
+#' For package-level connection reuse, consider delegating connection lifetime
+#' management to the pool package. If a package manages a long-lived connection
+#' itself, any finalizer that calls `dbDisconnect()` should keep the connection
+#' object reachable until the finalizer runs, and should check [dbIsValid()]
+#' before disconnecting.
+#'
 #' @inheritParams dbGetQuery
 #' @family DBIConnection generics
 #' @export

--- a/man/dbDisconnect.Rd
+++ b/man/dbDisconnect.Rd
@@ -32,6 +32,15 @@ already disconnected
 or invalid connection.
 
 }
+\section{Connection lifetime in packages}{
+
+For package-level connection reuse, consider delegating connection lifetime
+management to the pool package. If a package manages a long-lived connection
+itself, any finalizer that calls \code{dbDisconnect()} should keep the connection
+object reachable until the finalizer runs, and should check \code{\link[=dbIsValid]{dbIsValid()}}
+before disconnecting.
+
+}
 
 \examples{
 \dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}

--- a/man/dbDisconnect.Rd
+++ b/man/dbDisconnect.Rd
@@ -21,6 +21,15 @@ resources (e.g., memory, sockets).
 
 \Sexpr[results=rd,stage=render]{DBI:::methods_as_rd("dbDisconnect")}
 }
+\section{Connection lifetime in packages}{
+
+For package-level connection reuse, consider delegating connection lifetime
+management to the pool package. If a package manages a long-lived connection
+itself, any finalizer that calls \code{dbDisconnect()} should keep the connection
+object reachable until the finalizer runs, and should check \code{\link[=dbIsValid]{dbIsValid()}}
+before disconnecting.
+}
+
 \section{Failure modes}{
 
 
@@ -30,15 +39,6 @@ but this cannot be tested automatically.
 At least one warning is issued immediately when calling \code{dbDisconnect()} on an
 already disconnected
 or invalid connection.
-
-}
-\section{Connection lifetime in packages}{
-
-For package-level connection reuse, consider delegating connection lifetime
-management to the pool package. If a package manages a long-lived connection
-itself, any finalizer that calls \code{dbDisconnect()} should keep the connection
-object reachable until the finalizer runs, and should check \code{\link[=dbIsValid]{dbIsValid()}}
-before disconnecting.
 
 }
 


### PR DESCRIPTION
Fixes #532.

This adds a short `dbDisconnect()` documentation section for package-level connection reuse. It keeps the guidance conservative:

- consider delegating connection lifetime management to the pool package
- if a package manages a long-lived connection itself, keep the connection object reachable until any finalizer runs
- guard finalizer disconnects with `dbIsValid()`

Checks:
- `git diff --check`
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests DBI_1.3.0.9010.tar.gz`