### PR TITLE
fix: correct vignette reference case in dbBind docs

### DIFF
--- a/R/15-dbBind.R
+++ b/R/15-dbBind.R
@@ -52,7 +52,7 @@
 #' unless you want to access the results in a paged way
 #' or you have a parameterized query that you want to reuse.
 #' This flow requires an active connection established by [dbConnect()].
-#' See also `vignette("dbi-advanced")` for a walkthrough.
+#' See also `vignette("DBI-advanced", package = "DBI")` for a walkthrough.
 #'
 #' 1. Use [dbSendQuery()] to create a result set object of class
 #'    [DBIResult-class].
@@ -87,7 +87,7 @@
 #' which should be sufficient
 #' unless you have a parameterized query that you want to reuse.
 #' This flow requires an active connection established by [dbConnect()].
-#' See also `vignette("dbi-advanced")` for a walkthrough.
+#' See also `vignette("DBI-advanced", package = "DBI")` for a walkthrough.
 #'
 #' 1. Use [dbSendQueryArrow()] to create a result set object of class
 #'    [DBIResultArrow-class].
@@ -112,7 +112,7 @@
 #' is implemented by [dbExecute()], which should be sufficient
 #' for non-parameterized queries.
 #' This flow requires an active connection established by [dbConnect()].
-#' See also `vignette("dbi-advanced")` for a walkthrough.
+#' See also `vignette("DBI-advanced", package = "DBI")` for a walkthrough.
 #'
 #' 1. Use [dbSendStatement()] to create a result set object of class
 #'    [DBIResult-class].


### PR DESCRIPTION
## Problem

The `dbBind()` documentation references `vignette("dbi-advanced")` (lowercase) in three places, but the actual vignette file is `DBI-advanced.Rmd`. On case-sensitive file systems (Linux), this produces:

```
Vignette 'dbi-advanced' not found
```

## Fix

Change `vignette("dbi-advanced")` to `vignette("DBI-advanced", package = "DBI")` in `R/15-dbBind.R` (lines 55, 90, 115). This matches the correct form already used in `vignettes/DBI.Rmd` and `vignettes/DBI-arrow.Rmd`.

## Scope

- 1 source file changed: `R/15-dbBind.R`
- 3 roxygen comments fixed (same pattern, all in `@section` blocks)
- `man/` Rd files should be regenerated by the maintainer (not included in this PR to avoid diffs from missing suggested packages)

## Validation

- `R CMD build` succeeded
- `R CMD check --no-manual --no-vignettes` passed with Status: OK
- Verified the fix matches the convention in the package's own vignettes

## Related

Similar to #683 which fixed a different vignette reference (`DBItest`) in `backend.Rmd`.