### PR TITLE
fix: typos in roxygen docs, vignette, and test names

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -27,7 +27,7 @@
 #' @inheritSection DBItest::spec_result_create_table_with_data_type Specification
 #'
 #' @inheritParams dbListConnections
-#' @param dbObj A object inheriting from [DBI::DBIDriver][DBIDriver-class]
+#' @param dbObj An object inheriting from [DBI::DBIDriver][DBIDriver-class]
 #'   or [DBI::DBIConnection][DBIConnection-class]
 #' @param obj An R object whose SQL type we want to determine.
 #' @family DBIDriver generics

--- a/R/dbDriver.R
+++ b/R/dbDriver.R
@@ -4,7 +4,7 @@
 #' These methods are deprecated, please consult the documentation of the
 #' individual backends for the construction of driver instances.
 #'
-#' `dbDriver()` is a helper method used to create an new driver object
+#' `dbDriver()` is a helper method used to create a new driver object
 #' given the name of a database or the corresponding R package. It works
 #' through convention: all DBI-extending packages should provide an exported
 #' object with the same name as the package. `dbDriver()` just looks for
@@ -21,7 +21,7 @@
 #' @param drv an object that inherits from `DBIDriver` as created by
 #'   `dbDriver`.
 #' @param ... any other arguments are passed to the driver `drvName`.
-#' @return In the case of `dbDriver`, an driver object whose class extends
+#' @return In the case of `dbDriver`, a driver object whose class extends
 #'   `DBIDriver`. This object may be used to create connections to the
 #'   actual DBMS engine.
 #'

--- a/R/dbGetConnectArgs.R
+++ b/R/dbGetConnectArgs.R
@@ -8,7 +8,7 @@
 #' @template methods
 #' @templateVar method_name dbGetConnectArgs
 #'
-#' @param drv A object inheriting from [DBIConnector-class].
+#' @param drv An object inheriting from [DBIConnector-class].
 #' @param eval Set to `FALSE` to return the functions that generate the argument
 #'   instead of evaluating them.
 #' @param ... Other arguments passed on to methods. Not otherwise used.

--- a/R/dbListConnections.R
+++ b/R/dbListConnections.R
@@ -3,7 +3,7 @@
 #' DEPRECATED, drivers are no longer required to implement this method.
 #' Keep track of the connections you opened if you require a list.
 #'
-#' @param drv A object inheriting from [DBIDriver-class]
+#' @param drv An object inheriting from [DBIDriver-class]
 #' @param ... Other arguments passed on to methods.
 #' @family DBIDriver generics
 #' @keywords internal

--- a/R/dbListResults.R
+++ b/R/dbListResults.R
@@ -1,6 +1,6 @@
 #' A list of all pending results
 #'
-#' DEPRECATED. DBI currenty supports only one open result set per connection,
+#' DEPRECATED. DBI currently supports only one open result set per connection,
 #' you need to keep track of the result sets you open if you need this
 #' functionality.
 #'

--- a/R/dbSetDataMappings.R
+++ b/R/dbSetDataMappings.R
@@ -1,4 +1,4 @@
-#' Set data mappings between an DBMS and R.
+#' Set data mappings between a DBMS and R.
 #'
 #' This generic is deprecated since no working implementation was ever produced.
 #'

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -17,7 +17,7 @@ test_that("no rownames in input gives no rownames in output", {
   expect_equal(sqlRownamesToColumn(df, NA)$row_name, NULL)
 })
 
-test_that("guess identify of row_names columns", {
+test_that("guess identity of row_names columns", {
   df <- data.frame(row_names = "a", x = 1, stringsAsFactors = FALSE)
 
   expect_equal(row.names(sqlColumnToRownames(df, NA)), "a")
@@ -25,7 +25,7 @@ test_that("guess identify of row_names columns", {
   expect_equal(row.names(sqlColumnToRownames(df, FALSE)), "1")
 })
 
-test_that("override identify of row_names column", {
+test_that("override identity of row_names column", {
   df <- data.frame(x = 1, y = "a", stringsAsFactors = FALSE)
 
   expect_equal(row.names(sqlColumnToRownames(df, "y")), "a")

--- a/vignettes/backend.Rmd
+++ b/vignettes/backend.Rmd
@@ -217,7 +217,7 @@ With these four methods in place, you can now use the default `dbGetQuery()` to 
 
 You're now on the home stretch, and can make your wrapper substantially more useful by implementing methods that wrap around variations in SQL across databases:
 
-* `dbQuoteString()` and `dbQuoteIdentifer()` are used to safely quote strings
+* `dbQuoteString()` and `dbQuoteIdentifier()` are used to safely quote strings
   and identifiers to avoid SQL injection attacks.  Note that the former must be
   vectorized, but not the latter.
 
@@ -227,7 +227,7 @@ You're now on the home stretch, and can make your wrapper substantially more use
   know if you have problems.
 
 * `dbReadTable()`: a simple wrapper around `SELECT * FROM table`. Use
-  `dbQuoteIdentifer()` to safely quote the table name and prevent mismatches
+  `dbQuoteIdentifier()` to safely quote the table name and prevent mismatches
   between the names allowed by R and the database.
 
 * `dbListTables()` and `dbExistsTable()` let you determine what tables are


### PR DESCRIPTION
## Summary

Fixes several typos in roxygen source, vignette, and test names:

**Vignette (backend.Rmd):**
- Fix `dbQuoteIdentifer()` to `dbQuoteIdentifier()` (broken function reference, lines 220 and 230)

**Roxygen docs (propagate to man pages):**
- `dbDriver.R`: "an new" to "a new", "an driver" to "a driver"
- `dbSetDataMappings.R`: "an DBMS" to "a DBMS"
- `dbListConnections.R`: "A object" to "An object"
- `dbGetConnectArgs.R`: "A object" to "An object"
- `dbDataType.R`: "A object" to "An object"
- `dbListResults.R`: "currenty" to "currently"

**Test names:**
- `test-rownames.R`: "guess identify" to "guess identity", "override identify" to "override identity"

## Validation

- `R CMD build` succeeded
- `R CMD check --no-manual` passed with Status: OK
- All changes are source-only; man page regeneration needed by maintainer with full dependency set
