### PR TITLE
fix: @family tags on quoting generics and typos in SQL-92 keywords

### DIFF
--- a/R/dbQuoteLiteral.R
+++ b/R/dbQuoteLiteral.R
@@ -15,7 +15,7 @@
 #' @inheritSection DBItest::spec_sql_quote_literal Failure modes
 #' @inheritSection DBItest::spec_sql_quote_literal Specification
 #'
-#' @family DBIResult generics
+#' @family DBIConnection generics
 #' @export
 #' @examples
 #' # Quoting ensures that arbitrary input is safe for use in a query

--- a/R/dbQuoteString.R
+++ b/R/dbQuoteString.R
@@ -15,7 +15,7 @@
 #' @inheritSection DBItest::spec_sql_quote_string Failure modes
 #' @inheritSection DBItest::spec_sql_quote_string Specification
 #'
-#' @family DBIResult generics
+#' @family DBIConnection generics
 #' @export
 #' @examples
 #' # Quoting ensures that arbitrary input is safe for use in a query

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -26,7 +26,7 @@ make.db.names.default <- function(
     out
   }
   ## Note: SQL identifiers *can* be enclosed in double or single quotes
-  ## when they are equal to reserverd keywords.
+  ## when they are equal to reserved keywords.
   fc <- substring(snames, 1, 1)
   lc <- substring(snames, nchar(snames))
   i <- match(fc, c("'", '"'), 0) > 0 & match(lc, c("'", '"'), 0) > 0
@@ -135,8 +135,8 @@ isSQLKeyword.default <- function(
   "DESCRIBE",
   "DESCRIPTOR",
   "DIAGNOSTICS",
-  "DICONNECT",
-  "DICTIONATRY",
+  "DISCONNECT",
+  "DICTIONARY",
   "DISPLACEMENT",
   "DISTINCT",
   "DOMAIN",
@@ -212,7 +212,7 @@ isSQLKeyword.default <- function(
   "NULL",
   "NULLIF",
   "NUMERIC",
-  "OCTECT_LENGTH",
+  "OCTET_LENGTH",
   "OF",
   "OFF",
   "ONLY",

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -36,7 +36,7 @@ sqlParseVariablesImpl <- function(sql, quotes, comments) {
   comment_spec_offset <- 0L
   sql_variable_start <- 0L
 
-  # prepare comments & quotes for quicker comparisions
+  # prepare comments & quotes for quicker comparisons
   for (c in seq_along(comments)) {
     comments[[c]][["start"]] <- str_to_vec(comments[[c]][["start"]])
     comments[[c]][["end"]] <- str_to_vec(comments[[c]][["end"]])


### PR DESCRIPTION
## Summary

Fixes two categories of issues in DBI source:

### Incorrect @family tags (affects generated "See Also" cross-references)

`dbQuoteString()` and `dbQuoteLiteral()` both take a `DBIConnection` as their first argument and dispatch on `DBIConnection`, but were tagged `@family DBIResult generics`. Their sibling `dbQuoteIdentifier()` is correctly tagged `@family DBIConnection generics`. This fix aligns all three quoting generics under the same family.

- `R/dbQuoteString.R`: `@family DBIResult generics` -> `@family DBIConnection generics`
- `R/dbQuoteLiteral.R`: `@family DBIResult generics` -> `@family DBIConnection generics`

### Typos in SQL-92 keywords data and code comments

The `.SQL92Keywords` vector in `R/deprecated.R` contained three misspelled keywords that could affect anyone using this list for identifier validation:

- `DICONNECT` -> `DISCONNECT`
- `DICTIONATRY` -> `DICTIONARY`
- `OCTECT_LENGTH` -> `OCTET_LENGTH`

Also fixed two comment typos:
- `R/deprecated.R`: `reserverd` -> `reserved`
- `R/interpolate.R`: `comparisions` -> `comparisons`

## Files changed
- `R/dbQuoteString.R` (roxygen tag)
- `R/dbQuoteLiteral.R` (roxygen tag)
- `R/deprecated.R` (data fixes + comment typo)
- `R/interpolate.R` (comment typo)

## Testing
- `devtools::test()`: PASS (109 tests, 3 skipped for missing optional deps)
- No man page regeneration performed (requires roxygen2 8.0.0.9000 dev version)
