### PR TITLE
fix: preserve exact double literals without forcing scientific notation

### DIFF
--- a/R/dbQuoteLiteral_DBIConnection.R
+++ b/R/dbQuoteLiteral_DBIConnection.R
@@ -48,6 +48,23 @@ dbQuoteLiteral_DBIConnection <- function(conn, x, ...) {
     return(SQL(blob_data, names = names(x)))
   }
 
+  if (is.double(x)) {
+    out <- as.character(x)
+    # Fall back to a longer decimal representation only when the default
+    # formatting does not round-trip to the original double value.
+    needs_precise <- is.finite(x) & (as.numeric(out) != x)
+    if (any(needs_precise)) {
+      out[needs_precise] <- formatC(
+        x[needs_precise],
+        digits = 17,
+        format = "fg",
+        flag = "#"
+      )
+    }
+    out[is.na(out)] <- "NULL"
+    return(SQL(out, names = names(x)))
+  }
+
   if (is.logical(x)) {
     x <- as.numeric(x)
   }

--- a/tests/testthat/test-quoting.R
+++ b/tests/testthat/test-quoting.R
@@ -13,3 +13,22 @@ test_that("single quotes are doubled surrounded by '", {
 test_that("special chars are escaped", {
   expect_equal(dbQuoteString(ANSI(), "\n"), SQL("'\n'"))
 })
+
+test_that("double literals round-trip when default formatting loses precision", {
+  x <- c(
+    0.0027392760273972603,
+    pi,
+    123456789.12345679
+  )
+
+  sql <- dbQuoteLiteral(ANSI(), x)
+
+  expect_identical(as.numeric(sql), x)
+})
+
+test_that("double literals keep simple exact representations when possible", {
+  expect_equal(
+    dbQuoteLiteral(ANSI(), c(1, 1e20, 1e-20)),
+    SQL(c("1", "1e+20", "1e-20"))
+  )
+})


### PR DESCRIPTION
Summary

Preserve exact `double` literals in `dbQuoteLiteral()` only when the default formatting would lose precision.

Thanks to maintainers

Thanks for the original issue discussion and for reverting the earlier scientific-notation change once reverse dependencies showed it was too broad.

Issue or motivation

`DBI::dbQuoteLiteral()` currently uses `as.character()` for `double` values. That loses precision for some values reported in `#404`, so quoted literals do not always round-trip back to the original number.

Root cause

The default character conversion for `double` values is readable, but it is not guaranteed to preserve the original binary value. The earlier fix switched all doubles to scientific notation, which fixed precision but changed unaffected literals more broadly than necessary.

Change

- Keep the existing `as.character()` output when it already round-trips exactly.
- Fall back to a longer decimal representation with `formatC(..., digits = 17, format = "fg", flag = "#")` only for finite `double` values where the default formatting loses precision.
- Add regression tests for precision-sensitive doubles and for simple values that should keep their existing representation.

Tests

- `Rscript -e 'pkgload::load_all(\".\", quiet = TRUE); testthat::test_file(\"tests/testthat/test-quoting.R\")'`
- `Rscript -e 'pkgload::load_all(\".\", quiet = TRUE); testthat::test_file(\"tests/testthat/test-sql-df.R\"); testthat::test_file(\"tests/testthat/test-interpolate.R\")'`
- `R CMD build .`
- `R CMD check --no-manual DBI_1.3.0.9010.tar.gz`

Scope

This does not change integer or logical quoting, does not reintroduce scientific notation for all doubles, and does not include the unrelated generated vignette file changes from local checks.
