### PR TITLE
fix(ci): Survive an archived website package, and run MariaDB 12.3 on Resolute

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -5,13 +5,28 @@ runs:
   steps:
     # Must happen after installing system dependencies,
     # https://github.com/ankane/setup-mariadb/issues/2
+    #
+    # The version has to be one MariaDB publishes for the runner's Ubuntu.
+    # `ubuntu-26.04` is Resolute, and the 10.11 line stops before it:
+    # `apt-get update` then fails the whole step with
+    # "The repository '.../mariadb-server/10.11/repo/ubuntu resolute Release'
+    # does not have a Release file".
+    # The action itself needs no help with a new codename -- it reads
+    # `lsb_release -cs` -- and its own CI matrix marks the boundary:
+    # `ubuntu-26.04` is tested with 12.3 and 11.8, 11.4 and 10.11 only up to
+    # `ubuntu-24.04`. 12.3 is the current LTS, what the download page serves for
+    # Resolute, and the action's own default.
     - uses: ankane/setup-mariadb@v1
       with:
-        mariadb-version: "10.11"
+        mariadb-version: "12.3"
 
     - name: Create database, set it to UTF-8
+      # MariaDB renamed its client binaries to `mariadb*` in 11.0 and keeps the
+      # `mysql*` names as deprecated symlinks, so prefer the name the server
+      # actually ships and fall back for anything older.
       run: |
-        mysql -e "CREATE DATABASE IF NOT EXISTS test; ALTER DATABASE test CHARACTER SET 'utf8'; FLUSH PRIVILEGES;"
+        client="$(command -v mariadb || command -v mysql)"
+        "${client}" -e "CREATE DATABASE IF NOT EXISTS test; ALTER DATABASE test CHARACTER SET 'utf8'; FLUSH PRIVILEGES;"
       shell: bash
 
     # Must happen after R is installed...

--- a/.github/workflows/get-website/action.yml
+++ b/.github/workflows/get-website/action.yml
@@ -1,0 +1,107 @@
+name: "Action to resolve Config/Needs/website against the configured repositories"
+inputs:
+  needs:
+    description: "The `needs` value the caller passed to the install action"
+    required: false
+    default: ""
+outputs:
+  needs:
+    description: "The `needs` value with `website` removed, once the field has been expanded here"
+    value: ${{ steps.get-website.outputs.needs }}
+  packages:
+    description: "The website packages as pak refs, with the ones no repository carries left out"
+    value: ${{ steps.get-website.outputs.packages }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve the website packages
+      # `needs: website` reaches pak as a dependency *type*
+      # (`lockfile_create(deps, dependencies = "Config/Needs/website")`),
+      # and a dependency type is resolved all-or-nothing:
+      # one entry that no repository carries fails the whole solve,
+      # before a single check runs.
+      # CRAN archives a backend from time to time --
+      # `adbi` and `RPresto` in September 2026 --
+      # and that must not take down a run that only wanted the website packages
+      # for the pkgdown reference index.
+      #
+      # No pak parameter reaches a dependency type:
+      # `?ignore-unavailable` is honoured for soft dependencies only,
+      # and `pkg=?ignore` drops the package even when it is available.
+      # So resolve the field here instead, and hand the result to pak as refs:
+      # every entry that is not a plain package name stays as it is and stays strict,
+      # every plain name the repositories carry is kept,
+      # and the rest is dropped with a warning in the job log.
+      # Nothing is removed from `DESCRIPTION`:
+      # a package that returns to CRAN is picked up again by the next run.
+      id: get-website
+      run: |
+        # `needs` is a comma- or space-separated list, the same spelling
+        # `r-lib/actions/setup-r-dependencies` accepts.
+        needs <- strsplit(trimws("${{ inputs.needs }}"), "[[:space:],]+")[[1]]
+        needs <- needs[nzchar(needs)]
+        refs <- character()
+
+        if ("website" %in% needs) {
+          needs <- setdiff(needs, "website")
+
+          # Read with read.dcf(), not `grep | cut`, for the reason `get-extra`
+          # spells out: a DCF value that wraps onto continuation lines is not
+          # what the first `grep` hit returns.
+          field <- read.dcf("DESCRIPTION", fields = "Config/Needs/website")[1, 1]
+
+          if (!is.na(field)) {
+            entries <- strsplit(trimws(gsub("[[:space:]]+", " ", field)), "[[:space:],]+")[[1]]
+            entries <- entries[nzchar(entries)]
+
+            # `setup-r` writes the RSPM repository into a user `.Rprofile`, so the
+            # repositories seen here are the ones pak resolves against. Fall back
+            # to CRAN for a local run that has no repository configured.
+            repos <- getOption("repos")
+            if (!length(repos) || any(repos == "@CRAN@")) {
+              options(repos = c(CRAN = "https://cloud.r-project.org"))
+            }
+            available <- available.packages()
+
+            # Only a plain name is looked up in a repository. An `owner/repo` or
+            # `type::ref` entry names a source of its own, and a broken one of
+            # those is a mistake in `DESCRIPTION` rather than an archival, so it
+            # keeps failing the run.
+            plain <- !grepl("[:/]", entries)
+            keep <- !plain | entries %in% rownames(available)
+
+            if (any(!keep)) {
+              cat(sprintf(
+                "::warning::Website packages left out, no configured repository carries them: %s\n",
+                paste(entries[!keep], collapse = ", ")
+              ))
+            }
+            refs <- entries[keep]
+
+            # A website package that is available can still suggest one that is
+            # not -- `duckdb` suggests the archived `adbcdrivermanager` -- and
+            # that fails the solve just as well. `pkg=?ignore-unavailable` is the
+            # parameter for exactly this case: it applies to soft dependencies,
+            # and only when the package is missing, so the dependency comes back
+            # by itself once the package does.
+            installed_base <- rownames(installed.packages(priority = "base"))
+            soft <- available[intersect(entries[keep & plain], rownames(available)), c("Suggests", "Enhances"), drop = FALSE]
+            soft <- unlist(strsplit(soft[!is.na(soft)], ","), use.names = FALSE)
+            soft <- trimws(sub("\\(.*", "", soft))
+            soft <- setdiff(unique(soft[nzchar(soft)]), c("R", installed_base, rownames(available)))
+
+            if (length(soft)) {
+              cat(sprintf(
+                "::warning::Soft dependencies of the website packages tolerated as unavailable: %s\n",
+                paste(soft, collapse = ", ")
+              ))
+              refs <- c(refs, paste0(soft, "=?ignore-unavailable"))
+            }
+          }
+        }
+
+        out <- Sys.getenv("GITHUB_OUTPUT")
+        cat("needs=", paste(needs, collapse = ","), "\n", sep = "", file = out, append = TRUE)
+        cat("packages=", paste(refs, collapse = " "), "\n", sep = "", file = out, append = TRUE)
+      shell: Rscript {0}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -128,6 +128,15 @@ runs:
       id: get-extra
       uses: ./.github/workflows/get-extra
 
+    - name: Resolve `Config/Needs/website` from DESCRIPTION
+      # Expands `needs: website` into refs, dropping the packages that CRAN has
+      # archived, so a website dependency that went away does not fail the solve
+      # for every job that asks for it. See the action for the full reasoning.
+      id: get-website
+      uses: ./.github/workflows/get-website
+      with:
+        needs: ${{ inputs.needs }}
+
     - name: Let sudo keep R library env vars (ubuntu-26.04 forbids `sudo -E`)
       # r-lib/actions/setup-r-dependencies installs pak with
       #   sudo -E --preserve-env=PATH env R -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), ...)'
@@ -153,9 +162,9 @@ runs:
         GITHUB_PAT: ${{ inputs.token }}
       with:
         pak-version: stable
-        needs: ${{ inputs.needs }}
+        needs: ${{ steps.get-website.outputs.needs }}
         packages: ${{ inputs.packages }}
-        extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}
+        extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }} ${{ steps.get-website.outputs.packages }}
         cache-version: ${{ inputs.cache-version }}
 
     - name: Add pkg.lock to .gitignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Config/Needs/website: r-dbi/DBItest, r-dbi/dbitemplate, adbi, AzureKusto,
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0.9000
+Config/roxygen2/version: 8.1.0.9000

--- a/R/methods_as_rd.R
+++ b/R/methods_as_rd.R
@@ -13,7 +13,22 @@ methods_as_rd <- function(method) {
     )[[1]]
     packages <- grep("/", packages, invert = TRUE, value = TRUE)
     for (package in packages) {
-      stopifnot(requireNamespace(package, quietly = TRUE))
+      # Loading a backend is what puts its S4 methods in front of
+      # findMethods() below, so a package that is missing costs this page the
+      # methods it implements -- but it must not cost the whole website.
+      # CRAN archives a backend from time to time, `adbi` and `RPresto` in
+      # September 2026, and the workflow then leaves it out of the website
+      # dependencies instead of failing the installation. Match that here:
+      # say which page lost which backend, and carry on.
+      if (!requireNamespace(package, quietly = TRUE)) {
+        message(
+          "methods_as_rd(",
+          paste(method, collapse = ", "),
+          "): ",
+          "not installed, its methods are missing from this page: ",
+          package
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Three blockers on the same path, each one visible only once the one before it was gone. `rcc` now gets from a dead solve all the way to a built website.

## 1. A website package that CRAN has archived

Every `rcc` run on `main` has failed since 2026-09-11, in the smoke test, before a single check ran:

```
! Could not solve package dependencies:
* deps::.:
  * Can't install dependency adbi
  * Can't install dependency RPresto
```

CRAN archived `adbi` (it requires the archived `adbcdrivermanager`) and `RPresto`, and both are named in `Config/Needs/website`. That field reaches pak as a dependency *type*, through `lockfile_create(dependencies = "Config/Needs/website")`, and a dependency type resolves all-or-nothing: one entry that no repository carries fails the whole solve.

No pak parameter reaches a dependency type. `deps::.?ignore-unavailable` does not, because parameters attach to the ref and not to its dependencies; `?ignore-unavailable` is documented for soft dependencies only; and `pkg=?ignore` drops the package even when it is available. So the new `get-website` action resolves the field itself and hands pak refs instead: an `owner/repo` entry stays as it is and stays strict, a plain name the configured repositories carry is kept, and the rest is dropped with a warning in the job log.

Dropping those two names is only half of it. `duckdb` is still on CRAN and still suggests the archived `adbcdrivermanager`, which fails the solve one level down. That one *is* a soft dependency, which is what `adbcdrivermanager=?ignore-unavailable` covers, so the action derives those refs from the `Suggests` and `Enhances` of the website packages it kept.

Nothing leaves `DESCRIPTION`: both packages stay listed, and a run picks them up again by itself once CRAN does.

## 2. MariaDB 10.11 does not reach Resolute

With the solve fixed, `Install R and the package dependencies` passes (7m52s, full website set) and the smoke test failed two seconds into `custom/after-install` instead — where `main` had been failing all along, on `rcc dev`, every day since 2026-09-09:

```
E: The repository 'https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/ubuntu resolute Release' does not have a Release file.
```

`ubuntu-26.04` is Resolute, and MariaDB publishes no Resolute suite for the 10.11 line. The action is not at fault and needs no change for a new codename — it builds the apt source from `lsb_release -cs`. Its own CI matrix marks where the lines end: `ubuntu-26.04` is tested with 12.3 and 11.8, while 11.4 and 10.11 stop at `ubuntu-24.04`. 12.3 is the current LTS, the action's own default, and what the MariaDB download page serves for Ubuntu 26.04 Resolute.

The client call moves with the server: MariaDB renamed its client binaries to `mariadb*` in 11.0 and keeps the `mysql*` names as deprecated symlinks, so the database is created with whichever name the server ships — `mariadb` first, `mysql` as the fallback.

## 3. `methods_as_rd()` required every backend to be installed

Past MariaDB, the smoke test reached the pkgdown build and failed there:

```
29. DBI:::methods_as_rd("dbAppendTable")
30. base::stopifnot(requireNamespace(package, quietly = TRUE))
42. cli::cli_abort("Failed to parse Rd in {.file {topic$file_in}}")
```

`methods_as_rd()` loads every plain name in `Config/Needs/website` so `findMethods()` sees the backends' S4 methods, and `stopifnot()` made a package that is not installed fatal. That was fine while every backend was installable; it is not fine now that the workflow deliberately leaves the archived ones out, because then every `\Sexpr` that calls it aborts the site. A missing backend now costs its page the methods it implements — reported by name, so a silently shorter "Methods in other packages" section can't pass unnoticed — instead of costing the whole website.

## Verification

The dependency fix was reproduced against this `DESCRIPTION` with the exact call `setup-r-dependencies` makes — same message, to the line — and then the refs the action emits were solved: 209 packages, every kept website package among them, and no `adbi`, `RPresto` or `adbcdrivermanager`. CI confirmed it: the install step passes on this branch where it aborts after ~60s on `main`, and `R CMD check` passes.

The MariaDB client fallback and the `mariadb`-first preference were exercised locally against stub binaries under the same `bash -eo pipefail` the runner uses; CI confirmed the setup step, 15 seconds, green.

The pkgdown abort was reproduced locally with `IN_PKGDOWN=true` (`requireNamespace(package, quietly = TRUE) is not TRUE`, the same abort) and the call returns after the fix.

## Trade-offs

A website package that disappears no longer fails the run: it produces a warning annotation in the job log, the site builds without it, and its methods are missing from the pages that would have linked them. That is deliberate, and both places say so out loud. Whether MariaDB 12.3 shifts anything the checks observe is what this run will say; 11.8 is the conservative alternative if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML