### PR TITLE
fix(ci): Demote arrow's build failure on aarch64 Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,16 @@ VignetteBuilder:
 Config/autostyle/scope: line_breaks
 Config/autostyle/strict: false
 Config/Needs/check: r-dbi/DBItest
+Config/gha/extra-packages: arrow=?ignore-build-errors
+Config/comment/gha/extra-packages: arrow ships no aarch64 Windows binary and
+    its configure script downloads the x86_64 libarrow, which the aarch64
+    linker cannot use, so the source build fails on the windows-11-arm entry
+    of the matrix and took the whole entry down with it. The parameter demotes
+    that build failure to a missing optional dependency, which is what the
+    package is: every test guards with skip_if_not_installed(), and the arrow
+    vignette sets knitr's error = TRUE outside pkgdown. Every other runner
+    installs the binary as before -- the parameter only takes effect when a
+    build actually fails. Drop it once arrow builds on aarch64 Windows.
 Config/Needs/website: r-dbi/DBItest, r-dbi/dbitemplate, adbi, AzureKusto,
     bigrquery, DatabaseConnector, dittodb, duckdb, implyr, lazysf, odbc,
     pool, RAthena, IMSMWU/RClickhouse, RH2, RJDBC, RMariaDB, RMySQL,


### PR DESCRIPTION
With #744 merged the smoke test is green and the version matrix ran for the first time in days: [run 3088](https://github.com/r-dbi/DBI/actions/runs/34684359588) on `main`, 18 jobs, **1 failure** — `rcc: windows-11-arm (4.6)`, 33 minutes in, while installing dependencies.

```
clang++ -shared ... -L../windows/r-libarrow-windows-x86_64-25.0.1/libclang-19.1.7 ...
lld: error: unable to find library -larrow_dataset
lld: error: unable to find library -larrow_acero
...
ERROR: compilation failed for package 'arrow'
```

`arrow` publishes no aarch64 Windows binary, so that runner builds it from source, and its configure script downloads the prebuilt **windows-x86_64** libarrow — which the aarch64 linker cannot use. Nothing in this package can fix that, and nothing in #744 caused it: the entry compiles every dependency from source because P3M publishes no aarch64 Windows binaries (as `versions-matrix/action.R` already documents), and the failure was simply invisible while `rcc` was dying in the smoke test.

## The fix

`Config/gha/extra-packages` is where this kit puts a dependency that cannot be built everywhere, and `=?ignore-build-errors` demotes the build failure to a missing optional dependency — which is what `arrow` is here:

- every test that touches it guards with `skip_if_not_installed()`;
- the arrow vignette sets knitr's `error = TRUE` outside pkgdown, so its chunks render the error rather than failing the check;
- `_R_CHECK_FORCE_SUGGESTS_=false` is already set by the kit.

Every other runner installs the binary exactly as before — the parameter only takes effect when a build actually fails. The `Config/comment/` twin records why, so the field can be dropped once arrow builds on that toolchain.

## What this PR's CI will and will not show

`rcc-full` runs only when `rcc-smoke` produced a versions matrix, and that step is skipped for a same-repository pull request. So **this branch's run will not reach the entry it fixes** — the proof is the next push or scheduled run on `main`. The ref form was checked with `pkgdepends::parse_pkg_refs()` (`type=param`, `package=arrow`, `params=ignore-build-errors`), which is the same mechanism `duckdb=?ignore-build-errors` uses in dm and duckdb-r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML)_