### PR TITLE
fix(ci): Skip the MariaDB server where MariaDB ships none

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -16,11 +16,23 @@ runs:
     # `ubuntu-26.04` is tested with 12.3 and 11.8, 11.4 and 10.11 only up to
     # `ubuntu-24.04`. 12.3 is the current LTS, what the download page serves for
     # Resolute, and the action's own default.
+    #
+    # MariaDB publishes no ARM64 Windows server at all -- the action downloads
+    # `mariadb-*-winx64.msi` and hands it to `msiexec`, which on
+    # `windows-11-arm` grinds for about four and a half minutes and then throws
+    # out of the action's `index.js`. That took the whole entry down before a
+    # single check ran. Nothing in this package's own test suite connects to
+    # this server (the suite uses RSQLite, and the vignettes connect to a remote
+    # host), so skipping the provisioning there costs no coverage and lets the
+    # entry do what it is for: prove that DBI builds and checks on Windows
+    # aarch64.
     - uses: ankane/setup-mariadb@v1
+      if: runner.os != 'Windows' || runner.arch != 'ARM64'
       with:
         mariadb-version: "12.3"
 
     - name: Create database, set it to UTF-8
+      if: runner.os != 'Windows' || runner.arch != 'ARM64'
       # MariaDB renamed its client binaries to `mariadb*` in 11.0 and keeps the
       # `mysql*` names as deprecated symlinks, so prefer the name the server
       # actually ships and fall back for anything older.


### PR DESCRIPTION
`rcc: windows-11-arm (4.6)` is the only red job on `main` (run 3090, 1 of 18). It dies in "Run the repository-specific after-install steps", before any check runs:

```
C:\Windows\System32\curl.exe -Ls -o mariadb.msi https://dlm.mariadb.com/MariaDB/mariadb-11.8.2/winx64-packages/mariadb-11.8.2-winx64.msi
msiexec /i mariadb.msi SERVICENAME=MariaDB /qn
   ... 4m45s later ...
C:\a\_actions\ankane\setup-mariadb\v1\index.js:16
    throw ret.error;
```

MariaDB publishes no ARM64 Windows server, so `ankane/setup-mariadb` falls back to the `winx64` MSI and `msiexec` cannot install it on that runner. This is not a version pin that can be nudged — there is nothing to point it at.

Nothing in DBI connects to that server. The test suite uses RSQLite (`grep -rn MariaDB tests/` finds nothing), and the vignettes that do use `RMariaDB::MariaDB()` connect to `relational.fel.cvut.cz`, not to `localhost`. So the provisioning is skipped on ARM Windows and kept everywhere else.

That lets the entry do what #745 was aiming at: prove DBI builds and checks on Windows aarch64. Previously it never got that far — `after-install` killed it first, both before and after the `arrow` fix.

The same upstream gap hits r-dbi/RMariaDB and r-dbi/RPostgres, which have been red daily for about two weeks. They need the opposite remedy, since their suites require a live server, and are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML)_